### PR TITLE
OAK no-more-autoload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 0.4.1 (PENDING - TBD)
 
-- Use `Kernel#autoload` instead of `require` to reduce min exec time.
 - `oak`, `oak.rb`, `enigma`, and `enigma.rb` published as executables from gem.
 
 

--- a/lib/oak.rb
+++ b/lib/oak.rb
@@ -8,28 +8,14 @@
 
 require_relative 'oak/version'
 require          'contracts'  # TODO: cut
-#
-# Many of our dependencies are used in only some flows.  We load them
-# via Kernel#autoload to shave time in bin/oak.rb on executions when
-# we just do a couple encodings or decodings and only with 1 set of
-# encoding options.
-#
-# This reduces the runtime of 'bin/oak.rb --help' from 0.57s to 0.16s
-# in tests on my Mac.  0.5s per invocation is kind of a big deal.
-#
-# This optimization only helps quick CLI invocations.  Fortunately,
-# longer-lived processes which use all the options are not hurt by
-# this.  With both greedy Kernel#require and lazy Kernel#autoload I
-# saw ~26s for 'make clean && time -p make test'.
-#
-autoload :StringScanner, 'strscan'
-autoload :Digest,        'digest'
-autoload :Base64,        'base64'
-autoload :LZ4,           'lz4-ruby'
-autoload :Zlib,          'zlib'
-autoload :Bzip2,         'bzip2/ffi'
-autoload :LZMA,          'lzma'
-autoload :OpenSSL,       'openssl'
+require          'strscan'
+require          'digest'
+require          'base64'
+require          'lz4-ruby'
+require          'zlib'
+require          'bzip2/ffi'
+require          'lzma'
+require          'openssl'
 
 # Some design desiderata with which I started this project.
 #


### PR DESCRIPTION
PR for `oak`.

Dang it, reverses https://github.com/ProsperWorks/oak/pull/3.

https://bugs.ruby-lang.org/issues/5653
> So I hereby declare the future deprecation of autoload. Ruby wil; keep autoload for a while, since 2.0 should keep compatibility to 1.9.
> But you don’t expect it will survive further future, e.g. 3.0.
>
> I strongly discourage the use of autoload in any standard libraries.
>
> matz.

Also, in other testing I found some flows where sometimes a dependent file would fail to load. :(